### PR TITLE
Make thank you messages optional and to add unique image to message

### DIFF
--- a/tg_shill_bot.py
+++ b/tg_shill_bot.py
@@ -1,6 +1,5 @@
 # stdlib
 import asyncio
-from email import message
 import functools
 import random
 import sys

--- a/tg_shill_bot.py
+++ b/tg_shill_bot.py
@@ -515,26 +515,6 @@ def validate_messages_settings(settings):
         "additionalProperties": False,
         "minProperties": 1,
     }
-
-    # schema = {
-    #     "type": "object",
-    #     "patternProperties": {
-    #         "^.+$": {
-    #             "type": "object",
-    #             "properties": {
-    #                 "text": {"type": "string",
-    #                         "pattern": "^[a-zA-Z0-9_]+$"},
-    #                 "image": {"type": "string"},
-    #                 },
-    #             },
-    #             "additionalProperties": False,
-    #             "required": [
-    #                 "text",
-    #             ],
-    #     },
-    #     "additionalProperties": False,
-    #     "minProperties": 1,
-    # }
     jsonschema.validate(settings, schema)
 
 


### PR DESCRIPTION
### Add unique image to message
Make it possible to add a different image to each message or add no image
```yaml
messages:
  one:
    image: images/grogugif.gif 
    text: |
      this is message 1
    
  two: 
    text: |
      this is message 2
```

### Make thank you messages optional
Tag in raid channel: 
```yaml
"add_thank_you": {"type": "boolean"},
```